### PR TITLE
fix(ci): correct CLI flag casing in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Process charter
       run: |
         cd charter
-        npx markdown-transclusion v1.md --stripFrontmatter > v1-expanded.md
+        npx markdown-transclusion v1.md --strip-frontmatter > v1-expanded.md
         echo "Charter processed to expanded markdown"
         cd ..
         node .github/scripts/build-site.js


### PR DESCRIPTION
- Change --stripFrontmatter to --strip-frontmatter
- Match documented CLI syntax for markdown-transclusion
- Prevent potential errors in CI when processing charter