### PR TITLE
fix(build): correct CLI flag to strip frontmatter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Process charter
       run: |
         cd charter
-        npx markdown-transclusion v1.md --stripFrontmatter > v1-expanded.md
+        npx markdown-transclusion v1.md --strip-frontmatter > v1-expanded.md
         echo "Charter processed to expanded markdown"
         cd ..
         node .github/scripts/build-site.js


### PR DESCRIPTION
Replaces invalid '--stripFrontmatter' with '--strip-frontmatter' for compatibility with CLI parser.